### PR TITLE
Hints in Ex4 are given one letter at a time

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -79,7 +79,17 @@ function Ex4(data,index,size){
 	
 	/** @Override */
 	this.giveHint = function (){
-		this.$input.val(this.data[this.index].to);
+		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
+		var answer = this.data[this.index].to;
+		var hint = answer.slice(0, this.hintsUsed);
+		var numberOfDots = answer.length - hint.length;
+		
+		// Add dots after the revealed letters, to show how long the answer is.
+		for (var i = 0; i < numberOfDots; i++) {
+			hint += ".";
+		}
+		
+		this.$input.val(hint);
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -31,6 +31,7 @@ Exercise.prototype = {
 	lang:    '',	//user language
 	startTime: 0,
 	isHintUsed: false,
+	hintsUsed: 0,
 	minRequirement: 1,
 	resultSubmitSource: Settings.ZEEGUU_EX_SOURCE_RECOGNIZE,//Defualt submission
 	successAnimationTime: 2000,
@@ -223,6 +224,7 @@ Exercise.prototype = {
 	handleHint: function () {
 		this.submitResult(this.data[this.index].id, Settings.ZEEGUU_EX_OUTCOME_HINT);
 		this.isHintUsed = true;
+		this.hintsUsed++;
 
 		this.giveHint();
 	},


### PR DESCRIPTION
Instead of showing the complete answer when the hint button is clicked, one letter is shown, followed by dots indicating how long the answer is. Every subsequent time the hint button is clicked, an extra letter is shown. For this, it was necessary to add the field 'hintsUsed' (default 0) to Exercise.js. If the addition of a new field is undesirable, a possible improvement is removing the 'isHintUsed' field, and refactoring the code to see whether 'hintsUsed > 0' instead of 'isHintUsed'.