### PR TITLE
Hints: dots go away when user wants to type answer

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -98,7 +98,7 @@ function Ex1(data,index,size){
 		
 		// Remove dots when user wants to type the answer.
 		var exerciseObject = this;
-		this.$input.val(hintWithDots).blur().on("focus", function(){ console.log(exerciseObject.isHintOnScreen);if(exerciseObject.isHintOnScreen){exerciseObject.$input.val(hint);console.log(hint);} });
+		this.$input.val(hintWithDots).blur().on("focus", function(){ if(exerciseObject.isHintOnScreen){exerciseObject.$input.val(hint);} });
 		this.isHintOnScreen = true;
 	};
 	

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -45,22 +45,6 @@ function Ex1(data,index,size){
 		var t = Util.getSelectedText();
 		this.$input.val(this.$input.val().trim() + " " + t);
 	};
-
-	/**
-	 * Formats the string for comparing
-	 * @param {String}, text, to be formatted
-	 * @return {String}, the formatted string
-	 * removes numbers and symbols, multiple space, tabs, new lines are replaced by single space
-	 * */
-	this.formatStringForCheck = function (text) {
-		return text.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "").replace(/\s\s+/g, ' ');
-	};
-	
-	/** @Override */
-	this.successCondition = function(){
-		return (this.formatStringForCheck(this.$input.val()) === this.formatStringForCheck(this.data[this.index].from));
-	};
-
 }
 
 Ex1.prototype = Object.create(TextInputExercise.prototype, {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -50,7 +50,7 @@ function Ex1(data,index,size){
 	this.next = function (){
 		this.$to.html("\""+this.data[this.index].to+"\"");
 		this.$context.html(this.data[this.index].context);
-		this.$input.val("").attr("placeholder", "");
+		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
 	};
 	
@@ -97,7 +97,7 @@ function Ex1(data,index,size){
 			}
 		}
 		
-		this.$input.attr("placeholder", hintWithDots);
+		this.$input.val("").attr("placeholder", "Hint: " + hintWithDots).focus();
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -50,12 +50,17 @@ function Ex1(data,index,size){
 	this.next = function (){
 		this.$to.html("\""+this.data[this.index].to+"\"");
 		this.$context.html(this.data[this.index].context);
-		this.$input.val("");
+		this.$input.val("").off("focus");
+		this.isHintOnScreen = false;
 		this.reStyleDom();
 	};
 	
 	this.updateInput = function() {
 		var t = Util.getSelectedText();
+		if (this.isHintOnScreen) {
+			this.$input.val("");
+			this.isHintOnScreen = false;
+		}
 		this.$input.val(this.$input.val().trim() + " " + t);
 	};
 	
@@ -80,7 +85,21 @@ function Ex1(data,index,size){
 	
 	/** @Override */
 	this.giveHint = function (){
-		this.$input.val(this.data[this.index].from);
+		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
+		var answer = this.data[this.index].from;
+		var hint = answer.slice(0, this.hintsUsed);
+		var numberOfDots = answer.length - hint.length;
+		
+		// Add dots after the revealed letters, to show how long the answer is.
+		var hintWithDots = hint;
+		for (var i = 0; i < numberOfDots; i++) {
+			hintWithDots += ".";
+		}
+		
+		// Remove dots when user wants to type the answer.
+		var exerciseObject = this;
+		this.$input.val(hintWithDots).blur().on("focus", function(){ console.log(exerciseObject.isHintOnScreen);if(exerciseObject.isHintOnScreen){exerciseObject.$input.val(hint);console.log(hint);} });
+		this.isHintOnScreen = true;
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -83,12 +83,18 @@ function Ex1(data,index,size){
 		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
 		var answer = this.data[this.index].from;
 		var hint = answer.slice(0, this.hintsUsed);
-		var numberOfDots = answer.length - hint.length;
 		
 		// Add dots after the revealed letters, to show how long the answer is.
 		var hintWithDots = hint;
-		for (var i = 0; i < numberOfDots; i++) {
-			hintWithDots += ".";
+		for (var i = hint.length; i < answer.length; i++) {
+			var character = answer.charAt(i);
+			
+			// Display spaces as spaces, not as dots
+			if (character === ' ') {
+				hintWithDots += character;
+			} else {
+				hintWithDots += '.';
+			}
 		}
 		
 		this.$input.attr("placeholder", hintWithDots);

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -4,26 +4,12 @@
 **/
 
 import $ from 'jquery';
-import Exercise from './exercise';
+import TextInputExercise from './textInputExercise';
 import Util from '../util';
 import Settings from "../settings";
 
-
 function Ex1(data,index,size){
-	
 	this.init(data,index,size);
-	
-	/** @Override */
-	this.cacheCustomDom = function(){	
-		this.$to 					= this.$elem.find("#ex-to");
-		this.$context 				= this.$elem.find("#ex-context");
-		this.$input 				= this.$elem.find("#ex-main-input");
-		this.$showSolution 			= this.$elem.find("#show_solution");
-		this.$checkAnswer 			= this.$elem.find("#check_answer");
-		this.$clickableText 		= this.$elem.find(".clickable-text");
-		this.$nextExercise			= this.$elem.find('#next-exercise');
-        this.$feedbackBtn			= this.$elem.find('#feedback');
-	};
 	
 	/** @Override */
 	this.bindUIActions = function(){
@@ -52,20 +38,12 @@ function Ex1(data,index,size){
 		this.$context.html(this.data[this.index].context);
 		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
+		this.answer = this.data[this.index].from;
 	};
 	
 	this.updateInput = function() {
 		var t = Util.getSelectedText();
 		this.$input.val(this.$input.val().trim() + " " + t);
-	};
-	
-	this.enterKeyup = function(event){
-		if(event.keyCode == 13){
-			if(!this.getInstanceState())//If in the primary state of footer
-				this.$checkAnswer.click();
-			else //If in the secondary state of footer
-				this.$nextExercise.click();
-		}
 	};
 
 	/**
@@ -79,43 +57,15 @@ function Ex1(data,index,size){
 	};
 	
 	/** @Override */
-	this.giveHint = function (){
-		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
-		var answer = this.data[this.index].from;
-		var hint = answer.slice(0, this.hintsUsed);
-		
-		// Add dots after the revealed letters, to show how long the answer is.
-		var hintWithDots = hint;
-		for (var i = hint.length; i < answer.length; i++) {
-			var character = answer.charAt(i);
-			
-			// Display spaces as spaces, not as dots
-			if (character === ' ') {
-				hintWithDots += character;
-			} else {
-				hintWithDots += '.';
-			}
-		}
-		
-		this.$input.val("").attr("placeholder", "Hint: " + hintWithDots).focus();
-	};
-	
-	/** @Override */
 	this.successCondition = function(){
 		return (this.formatStringForCheck(this.$input.val()) === this.formatStringForCheck(this.data[this.index].from));
 	};
 
-
-	/** @Override */
-	this.wrongAnswerAnimation = function(){
-		this.shake.shakeElement(this.$input);
-	};
-
 }
 
-Ex1.prototype = Object.create(Exercise.prototype, {
+Ex1.prototype = Object.create(TextInputExercise.prototype, {
 	constructor: Ex1,
-	/************************** SETTINGS ********************************/	
+	/************************** SETTINGS ********************************/
 	description: {value: "Find the word in the context:"},
 	customTemplateURL: {value: 'static/template/exercise/ex1.html'},
 	resultSubmitSource: {value: Settings.ZEEGUU_EX_SOURCE_RECOGNIZE},

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -50,17 +50,12 @@ function Ex1(data,index,size){
 	this.next = function (){
 		this.$to.html("\""+this.data[this.index].to+"\"");
 		this.$context.html(this.data[this.index].context);
-		this.$input.val("").off("focus");
-		this.isHintOnScreen = false;
+		this.$input.val("").attr("placeholder", "");
 		this.reStyleDom();
 	};
 	
 	this.updateInput = function() {
 		var t = Util.getSelectedText();
-		if (this.isHintOnScreen) {
-			this.$input.val("");
-			this.isHintOnScreen = false;
-		}
 		this.$input.val(this.$input.val().trim() + " " + t);
 	};
 	
@@ -96,10 +91,7 @@ function Ex1(data,index,size){
 			hintWithDots += ".";
 		}
 		
-		// Remove dots when user wants to type the answer.
-		var exerciseObject = this;
-		this.$input.val(hintWithDots).blur().on("focus", function(){ if(exerciseObject.isHintOnScreen){exerciseObject.$input.val(hint);} });
-		this.isHintOnScreen = true;
+		this.$input.attr("placeholder", hintWithDots);
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -46,7 +46,7 @@ function Ex4(data,index,size){
 	this.next = function (){			
 		this.$to.html("\""+this.data[this.index].from +"\"");
 		this.$context.html(this.generateContext());
-		this.$input.val("").attr("placeholder", "");
+		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
 	};
 	
@@ -94,7 +94,7 @@ function Ex4(data,index,size){
 			}
 		}
 		
-		this.$input.attr("placeholder", hintWithDots);
+		this.$input.val("").attr("placeholder", "Hint: " + hintWithDots).focus();
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -46,8 +46,7 @@ function Ex4(data,index,size){
 	this.next = function (){			
 		this.$to.html("\""+this.data[this.index].from +"\"");
 		this.$context.html(this.generateContext());
-		this.$input.val("").off("focus");
-		this.isHintOnScreen = false;
+		this.$input.val("").attr("placeholder", "");
 		this.reStyleDom();
 	};
 	
@@ -89,9 +88,7 @@ function Ex4(data,index,size){
 			hintWithDots += ".";
 		}
 		
-		// Remove dots when user wants to type the answer.
-		var exerciseObject = this;
-		this.$input.val(hintWithDots).blur().on("focus", function(){ exerciseObject.$input.val(hint); });
+		this.$input.attr("placeholder", hintWithDots);
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -38,11 +38,6 @@ function Ex4(data,index,size){
 		this.answer = this.data[this.index].to;
 	};
 	
-	this.updateInput = function() {
-		var t = Util.getSelectedText();
-		this.$input.val(t);
-	};
-	
 	this.generateContext = function(){
 		var contextString = this.data[this.index].context;
 		var res = this.data[this.index].from.split(" ");	
@@ -53,13 +48,6 @@ function Ex4(data,index,size){
 			
 		return contextString;		
 	};
-	
-	/** @Override */
-	this.successCondition = function(){	
-		// Check all the possible answers
-		return this.$input.val().trim().toUpperCase().replace(/[^a-zA-Z ]/g, "") === this.data[this.index].to.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "");
-	};
-	
 };
 
 Ex4.prototype = Object.create(TextInputExercise.prototype, {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -4,25 +4,12 @@
 **/
 
 import $ from 'jquery';
-import Exercise from './exercise';
+import TextInputExercise from './textInputExercise';
 import Util from '../util';
 import Settings from "../settings";
 
 function Ex4(data,index,size){
-	
 	this.init(data,index,size);
-	
-	/** @Override */
-	this.cacheCustomDom = function(){	
-		this.$to 					= this.$elem.find("#ex-to");
-		this.$context 				= this.$elem.find("#ex-context");
-		this.$input 				= this.$elem.find("#ex-main-input");
-		this.$showSolution 			= this.$elem.find("#show_solution");
-		this.$checkAnswer 			= this.$elem.find("#check_answer");
-		this.$clickableText 		= this.$elem.find(".clickable-text");
-		this.$nextExercise			= this.$elem.find('#next-exercise');
-        this.$feedbackBtn			= this.$elem.find('#feedback');
-	};
 	
 	/** @Override */
 	this.bindUIActions = function(){
@@ -48,20 +35,12 @@ function Ex4(data,index,size){
 		this.$context.html(this.generateContext());
 		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
+		this.answer = this.data[this.index].to;
 	};
 	
 	this.updateInput = function() {
 		var t = Util.getSelectedText();
 		this.$input.val(t);
-	};
-	
-	this.enterKeyup = function(event){
-		if(event.keyCode == 13){
-			if(!this.getInstanceState())//If in the primary state of footer
-				this.$checkAnswer.click();
-			else //If in the secondary state of footer
-				this.$nextExercise.click();
-		}
 	};
 	
 	this.generateContext = function(){
@@ -76,46 +55,19 @@ function Ex4(data,index,size){
 	};
 	
 	/** @Override */
-	this.giveHint = function (){
-		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
-		var answer = this.data[this.index].to;
-		var hint = answer.slice(0, this.hintsUsed);
-		
-		// Add dots after the revealed letters, to show how long the answer is.
-		var hintWithDots = hint;
-		for (var i = hint.length; i < answer.length; i++) {
-			var character = answer.charAt(i);
-			
-			// Display spaces as spaces, not as dots
-			if (character === ' ') {
-				hintWithDots += character;
-			} else {
-				hintWithDots += '.';
-			}
-		}
-		
-		this.$input.val("").attr("placeholder", "Hint: " + hintWithDots).focus();
-	};
-	
-	/** @Override */
 	this.successCondition = function(){	
 		// Check all the possible answers
 		return this.$input.val().trim().toUpperCase().replace(/[^a-zA-Z ]/g, "") === this.data[this.index].to.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "");
 	};
-
-	/** @Override */
-	this.wrongAnswerAnimation = function(){
-		this.shake.shakeElement(this.$input);
-	}
 	
 };
-Ex4.prototype = Object.create(Exercise.prototype, {
+
+Ex4.prototype = Object.create(TextInputExercise.prototype, {
 	constructor: Ex4,
-	/************************** SETTINGS ********************************/	
+	/************************** SETTINGS ********************************/
 	description: {value: "Translate the word given in the context."},
 	customTemplateURL: {value: 'static/template/exercise/ex4.html'},
 	resultSubmitSource: {value: Settings.ZEEGUU_EX_SOURCE_TRANSLATE},
 });
 
 export default Ex4;
-

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -80,12 +80,18 @@ function Ex4(data,index,size){
 		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
 		var answer = this.data[this.index].to;
 		var hint = answer.slice(0, this.hintsUsed);
-		var numberOfDots = answer.length - hint.length;
 		
 		// Add dots after the revealed letters, to show how long the answer is.
 		var hintWithDots = hint;
-		for (var i = 0; i < numberOfDots; i++) {
-			hintWithDots += ".";
+		for (var i = hint.length; i < answer.length; i++) {
+			var character = answer.charAt(i);
+			
+			// Display spaces as spaces, not as dots
+			if (character === ' ') {
+				hintWithDots += character;
+			} else {
+				hintWithDots += '.';
+			}
 		}
 		
 		this.$input.attr("placeholder", hintWithDots);

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -46,8 +46,8 @@ function Ex4(data,index,size){
 	this.next = function (){			
 		this.$to.html("\""+this.data[this.index].from +"\"");
 		this.$context.html(this.generateContext());
-		this.$input.val("");
-
+		this.$input.val("").off("focus");
+		this.isHintOnScreen = false;
 		this.reStyleDom();
 	};
 	
@@ -76,7 +76,6 @@ function Ex4(data,index,size){
 		return contextString;		
 	};
 	
-	
 	/** @Override */
 	this.giveHint = function (){
 		// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
@@ -85,11 +84,14 @@ function Ex4(data,index,size){
 		var numberOfDots = answer.length - hint.length;
 		
 		// Add dots after the revealed letters, to show how long the answer is.
+		var hintWithDots = hint;
 		for (var i = 0; i < numberOfDots; i++) {
-			hint += ".";
+			hintWithDots += ".";
 		}
 		
-		this.$input.val(hint);
+		// Remove dots when user wants to type the answer.
+		var exerciseObject = this;
+		this.$input.val(hintWithDots).blur().on("focus", function(){ exerciseObject.$input.val(hint); });
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -32,7 +32,6 @@ Exercise.prototype = {
 	startTime: 0,
 	isHintUsed: false,
 	hintsUsed: 0,
-	isHintOnScreen: false,
 	minRequirement: 1,
 	resultSubmitSource: Settings.ZEEGUU_EX_SOURCE_RECOGNIZE,//Defualt submission
 	successAnimationTime: 2000,

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -32,6 +32,7 @@ Exercise.prototype = {
 	startTime: 0,
 	isHintUsed: false,
 	hintsUsed: 0,
+	isHintOnScreen: false,
 	minRequirement: 1,
 	resultSubmitSource: Settings.ZEEGUU_EX_SOURCE_RECOGNIZE,//Defualt submission
 	successAnimationTime: 2000,
@@ -190,6 +191,7 @@ Exercise.prototype = {
 		//If the user used the hint, do not register correct solution, resent the hint, move on
 		if (this.isHintUsed && exOutcome == Settings.ZEEGUU_EX_OUTCOME_CORRECT) {
 			this.isHintUsed = false;
+			this.hintsUsed = 0;
 			return;
 		}
 		//If hint is used twice, ignore request

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -29,6 +29,7 @@ Exercise.prototype = {
 	description: "Solve the exercise",  //default description
 	session: Session.getSession(), //Example of session id 34563456 or 11010001
 	lang:    '',	//user language
+	answer: "",
 	startTime: 0,
 	isHintUsed: false,
 	hintsUsed: 0,

--- a/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
@@ -1,4 +1,4 @@
-/** Modular Zeeguu Powered Text Input Exercise @author Martin Avagyan
+/** Modular Zeeguu Powered Text Input Exercise @author Martin Avagyan, Sibren van Vliet
  *  @initialize it using: new TextInputExercise();
  *  @customize it by using prototypal inheritance
  **/
@@ -61,6 +61,21 @@ TextInputExercise.prototype.giveHint = function() {
 
 TextInputExercise.prototype.wrongAnswerAnimation = function(){
 	this.shake.shakeElement(this.$input);
+};
+
+/**
+ * Formats the string for comparing
+ * @param {String}, text, to be formatted
+ * @return {String}, the formatted string
+ * removes numbers and symbols, multiple space, tabs, new lines are replaced by single space
+ * */
+TextInputExercise.prototype.formatStringForCheck = function (text) {
+	return text.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "").replace(/\s\s+/g, ' ');
+};
+
+TextInputExercise.prototype.successCondition = function(){	
+	// Check all the possible answers
+	return this.$input.val().trim().toUpperCase().replace(/[^a-zA-Z ]/g, "") === this.answer.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "");
 };
 
 export default TextInputExercise;

--- a/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
@@ -1,0 +1,66 @@
+/** Modular Zeeguu Powered Text Input Exercise @author Martin Avagyan
+ *  @initialize it using: new TextInputExercise();
+ *  @customize it by using prototypal inheritance
+ **/
+
+import $ from 'jquery';
+import Exercise from './exercise';
+import Util from '../util';
+import Settings from "../settings";
+
+var TextInputExercise = function (data, index, size) {
+	this.init(data, index, size);
+	//TODO unbind method
+};
+
+TextInputExercise.prototype = Object.create(Exercise.prototype, {
+	constructor: TextInputExercise,
+	/************************** SETTINGS ********************************/
+});
+
+
+TextInputExercise.prototype.cacheCustomDom = function(){	
+	this.$to            = this.$elem.find("#ex-to");
+	this.$context       = this.$elem.find("#ex-context");
+	this.$input         = this.$elem.find("#ex-main-input");
+	this.$showSolution  = this.$elem.find("#show_solution");
+	this.$checkAnswer   = this.$elem.find("#check_answer");
+	this.$clickableText = this.$elem.find(".clickable-text");
+	this.$nextExercise  = this.$elem.find('#next-exercise');
+	this.$feedbackBtn   = this.$elem.find('#feedback');
+};
+
+TextInputExercise.prototype.enterKeyup = function(event){
+	if(event.keyCode == 13){
+		if(!this.getInstanceState())//If in the primary state of footer
+			this.$checkAnswer.click();
+		else //If in the secondary state of footer
+			this.$nextExercise.click();
+	}
+};
+
+TextInputExercise.prototype.giveHint = function() {
+	// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
+	var hint = this.answer.slice(0, this.hintsUsed);
+	
+	// Add dots after the revealed letters, to show how long the answer is.
+	var hintWithDots = hint;
+	for (var i = hint.length; i < this.answer.length; i++) {
+		var character = this.answer.charAt(i);
+		
+		// Display spaces as spaces, not as dots
+		if (character === ' ') {
+			hintWithDots += character;
+		} else {
+			hintWithDots += '.';
+		}
+	}
+	
+	this.$input.val("").attr("placeholder", "Hint: " + hintWithDots).focus();
+};
+
+TextInputExercise.prototype.wrongAnswerAnimation = function(){
+	this.shake.shakeElement(this.$input);
+};
+
+export default TextInputExercise;


### PR DESCRIPTION
This pull request is for Issue #112

The dots that appear at the end of a hint, now go away when the user wants to type the answer. This improves user friendliness: the user no longer has to erase the dots on their own. To achieve this, the input textbox has a focus trigger event, which sets the value to a 'hint without dots'.

For Ex 1, implementing the hints one letter at a time was a bit trickier, because the user can also click words to append them to the input value. But if they got the hint "h..." and click the word "hint", we don't want the text box to say "h... hint". So the text box needs to be cleared only if the hint is on screen. To track this, I added a new variable in exercise.js, 'isHintOnScreen'.

I can imagine that introducing new variables like this causes some clutter, so for my next pull request in this issue I could do some refactoring.