### PR TITLE
See translation after answering correctly

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -52,7 +52,7 @@ function Ex1(data,index,size){
 		var res = inputWord.split(" ");	
 		
 		for (var i = 0; i <res.length; i++){
-			contextString = contextString.replace(res[i], res[i].bold());
+			contextString = contextString.replace(res[i], res[i].bold().fontcolor("#7ca500"));
 		}
 		
 		this.$context.html (contextString);

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -45,6 +45,22 @@ function Ex1(data,index,size){
 		var t = Util.getSelectedText();
 		this.$input.val(this.$input.val().trim() + " " + t);
 	};
+	
+	this.reGenerateContext = function(inputWord){
+		var contextString = this.data[this.index].context;
+		var res = inputWord.split(" ");	
+		
+		for (var i = 0; i <res.length; i++){
+			contextString = contextString.replace(res[i], res[i].bold());
+		}
+		
+		this.$context.html (contextString);
+	};
+	
+	this.exerciseSpecificSuccessHandler = function() {
+		// Success handling specific to this exercise
+		this.reGenerateContext(this.$input.val());
+	};
 }
 
 Ex1.prototype = Object.create(TextInputExercise.prototype, {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -47,12 +47,14 @@ function Ex1(data,index,size){
 		this.$input.val(this.$input.val().trim() + " " + t);
 	};
 	
+	// Re-print the context on screen, with the solution
+	// highlighted in boldface and green colour.
 	this.reGenerateContext = function(inputWord){
 		var contextString = this.data[this.index].context;
 		var res = inputWord.split(" ");	
 		
 		for (var i = 0; i <res.length; i++){
-			contextString = contextString.replace(res[i], res[i].bold().fontcolor("#7ca500"));
+			contextString = contextString.replace(res[i], res[i].bold().fontcolor(this.colourDarkGreen));
 		}
 		
 		this.$context.html (contextString);

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -39,6 +39,7 @@ function Ex1(data,index,size){
 		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
 		this.answer = this.data[this.index].from;
+		this.$descriptionContainer.removeClass('hide');
 	};
 	
 	this.updateInput = function() {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -149,7 +149,7 @@ function Ex2(data,index,size){
 	
 	this.exerciseSpecificSuccessHandler = function() {
 		// Success handling specific to this exercise
-		var translation = this.data[this.index].to.bold().fontcolor("#7ca500");
+		var translation = this.data[this.index].to.bold().fontcolor(this.colourDarkGreen);
 		this.$to.html (translation);
 	};
 };

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -68,6 +68,7 @@ function Ex2(data,index,size){
 		populateButton(this.btns[2], this.data[idxs[1]].from);
 
 		this.reStyleDom();
+		this.$descriptionContainer.removeClass('hide');
 	}
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -7,6 +7,7 @@ function Ex2(data,index,size){
 	
 	/** @Override */
 	this.cacheCustomDom = function(){	
+	  this.$to            = this.$elem.find("#ex-to");
 		this.$context 				= this.$elem.find("#ex-context");
 		this.$showSolution 			= this.$elem.find("#show_solution");
 		this.$checkAnswer 			= this.$elem.find("#check_answer");		
@@ -68,6 +69,7 @@ function Ex2(data,index,size){
 		populateButton(this.btns[2], this.data[idxs[1]].from);
 
 		this.reStyleDom();
+		this.$to.html ("&zwnj;");
 		this.$descriptionContainer.removeClass('hide');
 	}
 	
@@ -147,6 +149,8 @@ function Ex2(data,index,size){
 	
 	this.exerciseSpecificSuccessHandler = function() {
 		// Success handling specific to this exercise
+		var translation = this.data[this.index].to.bold().fontcolor("#7ca500");
+		this.$to.html (translation);
 	};
 };
 

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -143,6 +143,10 @@ function Ex2(data,index,size){
 		}	
 		this.$context.html (contextString);
 	};
+	
+	this.exerciseSpecificSuccessHandler = function() {
+		// Success handling specific to this exercise
+	};
 };
 
 Ex2.prototype = Object.create(Exercise.prototype, {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex3.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex3.js
@@ -145,7 +145,8 @@ function Ex3(data,index,size){
 	};
 	
 	/** @Override */
-	this.next = function (){	
+	this.next = function (){
+		this.$descriptionContainer.removeClass('hide');
 		this.populateButtons();
 	};
 	

--- a/src/zeeguu_exercises/static/js/app/exercises/ex3.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex3.js
@@ -227,6 +227,9 @@ function Ex3(data,index,size){
 		return arr;
 	};
 	
+	this.exerciseSpecificSuccessHandler = function() {
+		// Success handling specific to this exercise
+	};
 };
 
 Ex3.prototype = Object.create(Exercise.prototype, {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -48,6 +48,10 @@ function Ex4(data,index,size){
 			
 		return contextString;		
 	};
+	
+	this.exerciseSpecificSuccessHandler = function() {
+		// Success handling specific to this exercise
+	};
 };
 
 Ex4.prototype = Object.create(TextInputExercise.prototype, {

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -52,6 +52,8 @@ function Ex4(data,index,size){
 	
 	this.exerciseSpecificSuccessHandler = function() {
 		// Success handling specific to this exercise
+		var translation = this.data[this.index].to.bold().fontcolor("#7ca500");
+		this.$to.html (translation);
 	};
 };
 

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -52,7 +52,7 @@ function Ex4(data,index,size){
 	
 	this.exerciseSpecificSuccessHandler = function() {
 		// Success handling specific to this exercise
-		var translation = this.data[this.index].to.bold().fontcolor("#7ca500");
+		var translation = this.data[this.index].to.bold().fontcolor(this.colourDarkGreen);
 		this.$to.html (translation);
 	};
 };

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -36,6 +36,7 @@ function Ex4(data,index,size){
 		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
 		this.answer = this.data[this.index].to;
+		this.$descriptionContainer.removeClass('hide');
 	};
 	
 	this.generateContext = function(){

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -31,7 +31,7 @@ function Ex4(data,index,size){
 
 	/** @Override */
 	this.next = function (){			
-		this.$to.html("\""+this.data[this.index].from +"\"");
+		this.$to.html ("&zwnj;");
 		this.$context.html(this.generateContext());
 		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
@@ -60,7 +60,7 @@ function Ex4(data,index,size){
 Ex4.prototype = Object.create(TextInputExercise.prototype, {
 	constructor: Ex4,
 	/************************** SETTINGS ********************************/
-	description: {value: "Translate the word given in the context."},
+	description: {value: "Translate the highlighted word."},
 	customTemplateURL: {value: 'static/template/exercise/ex4.html'},
 	resultSubmitSource: {value: Settings.ZEEGUU_EX_SOURCE_TRANSLATE},
 });

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -38,6 +38,7 @@ Exercise.prototype = {
 	successAnimationTime: 2000,
 	exFeedback: 0,
 	instanceCorrect: false,
+	colourDarkGreen: "#7ca500",
 
 	/*********************** General Functions ***************************/
 	/**

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -56,6 +56,7 @@ Exercise.prototype = {
 		this.$description  		= this.$elem.find("#ex-descript");
 		this.$loader 			= this.$elem.find('#loader');
 		this.$statusContainer 	= this.$elem.find('#ex-status-container');
+		this.$descriptionContainer = this.$elem.find('#ex-description-container');
 		this.$exFooterPrimary 	= this.$elem.find('#ex-footer-primary');
 		this.$exFooterSecondary = this.$elem.find('#ex-footer-secondary');
 		this.$deleteBtn			= this.$elem.find('#btn-delete');
@@ -345,6 +346,7 @@ Exercise.prototype = {
 	**/
 	animateSuccess: function(){
 		let _this = this;
+		this.$descriptionContainer.addClass('hide');
 		this.$statusContainer.removeClass('hide');
 		setTimeout(function(){
 			if (_this.$statusContainer.length > 0) {

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -144,6 +144,7 @@ Exercise.prototype = {
 		//Submit the result of translation
 		this.submitResult(this.data[this.index].id, Settings.ZEEGUU_EX_OUTCOME_CORRECT);
 		this.setInstanceState(true);//Turn on the instance, instance was correctly solved
+		this.exerciseSpecificSuccessHandler();
 	},
 
 

--- a/src/zeeguu_exercises/static/styles/custom.css
+++ b/src/zeeguu_exercises/static/styles/custom.css
@@ -431,7 +431,7 @@ body
 }
 
 #ex-status{
-	height: 56px;
+	height: 60px;
 }
 #ex-status-container{
 	

--- a/src/zeeguu_exercises/static/styles/responsive.css
+++ b/src/zeeguu_exercises/static/styles/responsive.css
@@ -17,6 +17,9 @@
     #ex-bar{
         border-radius: 0px 15px 15px 0px;
     }
+		#ex-status{
+			height: 95px;
+		}
     .progress-module
     {
         margin-bottom: 0;
@@ -52,8 +55,7 @@
         height: 40px;
     }
     #ex-status{
-        height: 40px;
-	    margin-bottom: 15px;
+        height: 130px;
     }
     .ex-content{
 

--- a/src/zeeguu_exercises/static/template/exercise/ex1.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex1.html
@@ -2,8 +2,7 @@
 
 <div>
 	<div class = "custom-header">
-		<div class="col-xs-12 text-center block-header">					
-			<p id = "ex-descript" class = "h3"></p>				
+		<div class="col-xs-12 text-center block-header">
 			<p id = "ex-to" class = "h3"></p>					
 		</div>
 	</div>

--- a/src/zeeguu_exercises/static/template/exercise/ex2.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex2.html
@@ -3,7 +3,6 @@
 <div>
 	<div class = "custom-header">
 		<div class="col-xs-12 text-center block-header">
-			<p id = "ex-descript" class = "h3"></p>
 			<p id = "ex-to" class = "h3"></p>
 		</div>
 	</div>

--- a/src/zeeguu_exercises/static/template/exercise/ex3.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex3.html
@@ -3,7 +3,6 @@
 <div>			
 	<div class = "custom-header">
 		<div class="col-xs-12 text-center block-header">
-			<p id = "ex-descript" class = "h3"></p>				
 			<p id = "ex-to" class = "h3"></p>					
 		</div>
 	</div>

--- a/src/zeeguu_exercises/static/template/exercise/ex4.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex4.html
@@ -3,8 +3,7 @@
 
 <div>	
 	<div class = "custom-header">
-		<div class="col-xs-12 text-center block-header">					
-			<p id = "ex-descript" class = "h3"></p>				
+		<div class="col-xs-12 text-center block-header">
 			<p id = "ex-to" class = "h3"></p>					
 		</div>
 	</div>

--- a/src/zeeguu_exercises/static/template/exercise/exercise.html
+++ b/src/zeeguu_exercises/static/template/exercise/exercise.html
@@ -17,6 +17,9 @@
 				</div>
 				<div class="col-xs-8">
 					<div id="ex-status">
+						<div id = "ex-description-container" class="col-xs-12 text-center block-header">
+							<p id = "ex-descript" class = "h3"></p>		
+						</div>
 						<div id = "ex-status-container" class = "status-animation hide"><svg id = "temp-ex-success" class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><circle class="checkmark__circle" cx="26" cy="26" r="25" fill="none"/><path class="checkmark__check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8"/></svg></div>
 					</div>
 				</div>


### PR DESCRIPTION
This pull request is for #97.

After the learner gave the correct answer to an exercise, the words of interest are now shown on screen in both the original language and the translation. This way, the learner can review his/her answer. This should aid the learning process.

The exercise description is moved to the status bar, to make more room for the solution text. When the success animation plays, the description is hidden.