### PR TITLE
Removed hints from Ex2

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -8,7 +8,6 @@ function Ex2(data,index,size){
 	/** @Override */
 	this.cacheCustomDom = function(){	
 		this.$context 				= this.$elem.find("#ex-context");
-		this.$showSolution 			= this.$elem.find("#show_solution");
 		this.$checkAnswer 			= this.$elem.find("#check_answer");		
 		this.$btn1 					= this.$elem.find("#btn1");
 		this.$btn2 					= this.$elem.find("#btn2");
@@ -19,9 +18,6 @@ function Ex2(data,index,size){
 	
 	/** @Override */
 	this.bindUIActions = function(){
-		//Bind UI action of Hint/Show solution to the function		
-		this.$showSolution.on("click", this.handleHint.bind(this));
-		
 		//Bind UI action of Check answer to the function
 		this.$checkAnswer.on("click", this.checkAnswer.bind(this));
 		
@@ -68,13 +64,6 @@ function Ex2(data,index,size){
 		populateButton(this.btns[2], this.data[idxs[1]].from);
 
 		this.reStyleDom();
-	}
-	
-	/** @Override */
-	this.giveHint = function (){
-		var elem = $('#btn'+this.btns[1]);
-		elem.prop('disabled', true);
-		elem.addClass("btn-danger");
 	}
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/template/exercise/ex2.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex2.html
@@ -18,11 +18,7 @@
     <div class = "responsive-footer">
 	<div class="row ex-footer">
         <div id = "ex-footer-primary" class = "mask mask-appear">
-            <div id = "show_solution" class="col-xs-3 ex-footer-elem ex-clickable ex-footer-elem-left" href="#">
-                <img  class="clickable-symbol clickable-symbol-size" src="static/img/grey-question.png">
-            </div>
-
-            <div class="col-xs-9 ex-footer-elem ex-clickable">
+            <div class="col-xs-12 ex-footer-elem ex-clickable">
                 <button type = "button" id = "btn1" class = "btn btn-default option-btn clickable-symbol"></button>
                 <button type = "button" id = "btn2" class = "btn btn-default option-btn clickable-symbol"></button>
                 <button type = "button" id = "btn3" class = "btn btn-default option-btn clickable-symbol"></button>


### PR DESCRIPTION
This pull request is for #58.

In order to make the layout of the three option buttons in Ex2 symmetrical, the hint button and functionality is removed here. It was decided that hint functionality is not necessary in Ex2, because the user cannot get stuck here. If they do not know the answer, they can simply guess by trying each option until they hit the right answer.