### PR TITLE
Give matched pairs in Ex3 a unique shade of green

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -34,7 +34,7 @@ function Ex1(data,index,size){
 	
 	/** @Override */
 	this.next = function (){
-		this.$to.html("\""+this.data[this.index].to+"\"");
+		this.$to.html(this.data[this.index].to);
 		this.$context.html(this.data[this.index].context);
 		this.$input.val("").attr("placeholder", "Type or click a word").focus();
 		this.reStyleDom();
@@ -69,7 +69,7 @@ function Ex1(data,index,size){
 Ex1.prototype = Object.create(TextInputExercise.prototype, {
 	constructor: Ex1,
 	/************************** SETTINGS ********************************/
-	description: {value: "Find the word in the context:"},
+	description: {value: "Find the word in the context"},
 	customTemplateURL: {value: 'static/template/exercise/ex1.html'},
 	resultSubmitSource: {value: Settings.ZEEGUU_EX_SOURCE_RECOGNIZE},
 });

--- a/src/zeeguu_exercises/static/js/app/exercises/ex3.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex3.js
@@ -78,7 +78,21 @@ function Ex3(data,index,size){
 	this.successDisableBtn = function(btnID){
 		var elem = $("#btn"+btnID);
 		elem.prop('disabled', true);
-		elem.addClass("btn-success");
+		elem.removeClass("btn-default");
+		
+		// Determine success button colour by number of correct answers
+		switch (this.correctAnswers) {
+			case 0:
+				elem.addClass("ex3-btn-dark-green");
+				break;
+			case 1:
+				elem.addClass("ex3-btn-medium-green");
+				break;
+			case 2:
+				elem.addClass("ex3-btn-light-green");
+				break;
+		}
+		
 	};
 	
 	//Checks if a button is disabled
@@ -114,8 +128,7 @@ function Ex3(data,index,size){
 			// Prepare the document
 			this.prepareDocument();
 			
-			// Reset buttons, answers, hints
-			this.resetBtns();
+			// Reset answers, hints
 			this.correctAnswers = 0;
 			this.hints = 0;
 		}
@@ -148,6 +161,7 @@ function Ex3(data,index,size){
 	this.next = function (){
 		this.$descriptionContainer.removeClass('hide');
 		this.populateButtons();
+		this.resetBtns();
 	};
 	
 	// Populates the buttons

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -60,7 +60,7 @@ function Ex4(data,index,size){
 Ex4.prototype = Object.create(TextInputExercise.prototype, {
 	constructor: Ex4,
 	/************************** SETTINGS ********************************/
-	description: {value: "Translate the highlighted word."},
+	description: {value: "Translate the highlighted word"},
 	customTemplateURL: {value: 'static/template/exercise/ex4.html'},
 	resultSubmitSource: {value: Settings.ZEEGUU_EX_SOURCE_TRANSLATE},
 });

--- a/src/zeeguu_exercises/static/styles/custom.css
+++ b/src/zeeguu_exercises/static/styles/custom.css
@@ -362,6 +362,24 @@ body
 {
 }
 
+.ex3-btn-dark-green, .ex3-btn-dark-green:hover
+{
+	color: white;
+	background: #7ca500;
+}
+
+.ex3-btn-medium-green, .ex3-btn-medium-green:hover
+{
+	color: black;
+	background: #adca52;
+}
+
+.ex3-btn-light-green, .ex3-btn-light-green:hover
+{
+	color: black;
+	background: #def0a5;
+}
+
 .centering
 {
     text-align: center;


### PR DESCRIPTION
This pull request is for Issue #124.

When two words are correctly matched in Ex3, they are highlighted in a certain shade of green. The first pair is dark green, the second pair is medium green, and the last pair is light green. This way, after solving the exercise, the user can review which word matches to which translation.