### PR TITLE
Show blank lines as one single line

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -51,12 +51,8 @@ function Ex1(data,index,size){
 	// highlighted in boldface and green colour.
 	this.reGenerateContext = function(inputWord){
 		var contextString = this.data[this.index].context;
-		var res = inputWord.split(" ");	
-		
-		for (var i = 0; i <res.length; i++){
-			contextString = contextString.replace(res[i], res[i].bold().fontcolor(this.colourDarkGreen));
-		}
-		
+		var solution = this.data[this.index].from;
+		contextString = contextString.replace(solution, solution.bold().fontcolor(this.colourDarkGreen));
 		this.$context.html (contextString);
 	};
 	

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -1,3 +1,8 @@
+/** Custom exercise for choosing a word to fit the context. Inherited from Exercise.js
+ *  @initialize it using: new Ex2();
+ *  @customize it by using prototypal inheritance 
+**/
+
 import $ from 'jquery';
 import Exercise from './exercise';
 import Settings from "../settings";
@@ -118,21 +123,14 @@ function Ex2(data,index,size){
 	
 	this.generateContext = function(){
 		var contextString = this.data[this.index].context;
-		var res = this.data[this.index].from.split(" ");	
-		
-		for (var i = 0; i <res.length; i++){
-			contextString = contextString.replace(res[i]," ______ ");
-		}
+		var solution = this.data[this.index].from;
+		contextString = contextString.replace(solution, " ______ ");
 		this.$context.html(contextString);
 	};
 	
 	this.reGenerateContext = function(chosenWord){
 		var contextString = this.$context.html();
-		var res = chosenWord.split(" ");	
-		
-		for (var i = 0; i <res.length; i++){
-			contextString = contextString.replace(" ______ ",res[i].bold());
-		}	
+		contextString = contextString.replace(" ______ ", chosenWord.bold());
 		this.$context.html (contextString);
 	};
 	

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -41,11 +41,8 @@ function Ex4(data,index,size){
 	
 	this.generateContext = function(){
 		var contextString = this.data[this.index].context;
-		var res = this.data[this.index].from.split(" ");	
-		
-		for (var i = 0; i <res.length; i++){
-			contextString = contextString.replace(res[i], res[i].bold());
-		}
+		var phrase = this.data[this.index].from;
+		contextString = contextString.replace(phrase, phrase.bold());
 			
 		return contextString;		
 	};


### PR DESCRIPTION
This pull request is for #132 .

There are three instances in the exercise code where a phrase in the context is replaced, by splitting the phrase into a list of separate words, called `res`, and then performing the `replace` operation on each element of `res`. All three instances of this caused problems. To solve this, the phrase no longer gets split, but instead the whole phrase is `replace`d in one go.

In Ex2, each word in the phrase showed up as a blank line. If the exercise is "___ ___!" and the possible choices are "apple", "hello world" and "banana", the answer is obviously "hello world" because it is the only with two words.

In Ex1 and Ex4, the program attempted to highlight the phrase by `replace`ing the first instance of each word. If the context is "Ten years is two years too long" and "two years" must be highlighted, it would result in "Ten **years** is **two** years too long". In another example, the phrase "the boat" in the context "There is the boat" would be highlighted as "**The**re is the **boat**".

Finally, Ex2 was the only file without an explanatory comment at the top, so I added one.