### PR TITLE
Lenient answer checking: Ignore accents

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jquery": "^3.2.1",
     "nsp": "^2.6.3",
     "nyc": "^11.0.2",
+		"remove-accents": "^0.4.2",
     "style-loader": "^0.18.2",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3",

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -63,6 +63,7 @@ function Ex1(data,index,size){
 	this.exerciseSpecificSuccessHandler = function() {
 		// Success handling specific to this exercise
 		this.reGenerateContext(this.$input.val());
+		this.$typoInformation.html(this.typoInformation);
 	};
 }
 

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -55,6 +55,7 @@ function Ex4(data,index,size){
 		// Success handling specific to this exercise
 		var translation = this.data[this.index].to.bold().fontcolor(this.colourDarkGreen);
 		this.$to.html (translation);
+		this.$typoInformation.html(this.typoInformation);
 	};
 };
 

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -40,6 +40,7 @@ Exercise.prototype = {
 	instanceCorrect: false,
 	colourDarkGreen: "#7ca500",
 	isMobileDevice: undefined,
+	typoInformation: "",
 
 	/*********************** General Functions ***************************/
 	/**

--- a/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
@@ -7,6 +7,7 @@ import $ from 'jquery';
 import Exercise from './exercise';
 import Util from '../util';
 import Settings from "../settings";
+import removeAccents from 'remove-accents';
 
 var TextInputExercise = function (data, index, size) {
 	this.init(data, index, size);
@@ -80,21 +81,18 @@ TextInputExercise.prototype.successCondition = function(){
 	
 	// Check exact match
 	if (input === answer) {
-		this.typoInformation = "Exact match";
+		this.typoInformation = "";
 		return true;
 	}
 	
-	/*
 	// Check exact match after removing accents
-	if (input.removeAccents() === answer.removeAccents()) {
-		this.typoInformation = "Exact match after removing accents";
+	if (removeAccents(input) === removeAccents(answer)) {
+		this.typoInformation = "Pay close attention to the accents!";
 		return true;
 	}
-	*/
 
-	// Check fudgy match
-	this.typoInformation = "Fudgy match";
-	return this.$input.val().trim().toUpperCase().replace(/[^a-zA-Z ]/g, "") === this.answer.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "");
+	// No checks were successful
+	return false;
 };
 
 export default TextInputExercise;

--- a/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
@@ -20,14 +20,15 @@ TextInputExercise.prototype = Object.create(Exercise.prototype, {
 
 
 TextInputExercise.prototype.cacheCustomDom = function(){	
-	this.$to            = this.$elem.find("#ex-to");
-	this.$context       = this.$elem.find("#ex-context");
-	this.$input         = this.$elem.find("#ex-main-input");
-	this.$showSolution  = this.$elem.find("#show_solution");
-	this.$checkAnswer   = this.$elem.find("#check_answer");
-	this.$clickableText = this.$elem.find(".clickable-text");
-	this.$nextExercise  = this.$elem.find('#next-exercise');
-	this.$feedbackBtn   = this.$elem.find('#feedback');
+	this.$to              = this.$elem.find("#ex-to");
+	this.$context         = this.$elem.find("#ex-context");
+	this.$input           = this.$elem.find("#ex-main-input");
+	this.$showSolution    = this.$elem.find("#show_solution");
+	this.$checkAnswer     = this.$elem.find("#check_answer");
+	this.$clickableText   = this.$elem.find(".clickable-text");
+	this.$nextExercise    = this.$elem.find('#next-exercise');
+	this.$feedbackBtn     = this.$elem.find('#feedback');
+	this.$typoInformation = this.$elem.find("#typo-information");
 };
 
 TextInputExercise.prototype.enterKeyup = function(event){
@@ -73,8 +74,26 @@ TextInputExercise.prototype.formatStringForCheck = function (text) {
 	return text.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "").replace(/\s\s+/g, ' ');
 };
 
-TextInputExercise.prototype.successCondition = function(){	
-	// Check all the possible answers
+TextInputExercise.prototype.successCondition = function(){
+	var input = this.$input.val().trim().toUpperCase().replace(/\s\s+/g, ' ');
+	var answer = this.answer.trim().toUpperCase().replace(/\s\s+/g, ' ');
+	
+	// Check exact match
+	if (input === answer) {
+		this.typoInformation = "Exact match";
+		return true;
+	}
+	
+	/*
+	// Check exact match after removing accents
+	if (input.removeAccents() === answer.removeAccents()) {
+		this.typoInformation = "Exact match after removing accents";
+		return true;
+	}
+	*/
+
+	// Check fudgy match
+	this.typoInformation = "Fudgy match";
 	return this.$input.val().trim().toUpperCase().replace(/[^a-zA-Z ]/g, "") === this.answer.trim().toUpperCase().replace(/[^a-zA-Z ]/g, "");
 };
 

--- a/src/zeeguu_exercises/static/styles/custom.css
+++ b/src/zeeguu_exercises/static/styles/custom.css
@@ -306,6 +306,13 @@ body
 	background: #cde786;
 }
 
+#typo-information
+{
+	color: #7ca500;
+	text-align: center;
+	margin: 25px auto auto;
+}
+
 #ex-footer-secondary
 {
 	align-items: stretch;

--- a/src/zeeguu_exercises/static/template/exercise/ex1.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex1.html
@@ -33,7 +33,7 @@
                 <button class = " text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div id = "typo-information" class="col-xs-6 ex-footer-elem h4">
+            <div id = "typo-information" class="col-xs-6 h4">
             </div>
 
             <div id = "next-exercise"class="col-xs-3 ex-footer-elem ex-clickable secondary-ex-footer-elem ex-footer-elem-right" href="#">

--- a/src/zeeguu_exercises/static/template/exercise/ex1.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex1.html
@@ -33,7 +33,7 @@
                 <button class = " text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div class="col-xs-6 ">
+            <div id = "typo-information" class="col-xs-6 ex-footer-elem h4">
             </div>
 
             <div id = "next-exercise"class="col-xs-3 ex-footer-elem ex-clickable secondary-ex-footer-elem ex-footer-elem-right" href="#">

--- a/src/zeeguu_exercises/static/template/exercise/ex4.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex4.html
@@ -35,7 +35,7 @@
                 <button class=" text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div class="col-xs-6 ">
+            <div id = "typo-information" class="col-xs-6 ex-footer-elem h4">
             </div>
 
             <div id="next-exercise"

--- a/src/zeeguu_exercises/static/template/exercise/ex4.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex4.html
@@ -35,7 +35,7 @@
                 <button class=" text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div id = "typo-information" class="col-xs-6 ex-footer-elem h4">
+            <div id = "typo-information" class="col-xs-6 h4">
             </div>
 
             <div id="next-exercise"


### PR DESCRIPTION
This pull request is for issue #127.

In a text-input exercise, if the only difference between the user input and the correct answer is accents on letters, the input is now considered correct. For example, if the user inputs "Nasse" but the real answer is "Nässe", this is accepted. A small message appears on the screen to inform the user that they did not use accents properly.

This pull request adds the NPM package [remove-accents](https://www.npmjs.com/package/remove-accents) to the dependencies. It offers the function `removeAccents(text)`. If `text` is `àáä`, the output of this function is `aaa`. By running both the user input and the real answer through `removeAccents`, we can check whether the results are equal when ignoring accents.

The field `typoInformation` is added to `exercise.js`. Currently it is only used to inform the user of improper accent use, but in the future it can also be used to inform the user of other small mistakes.