### PR TITLE
Vertically center typo information

### DIFF
--- a/src/zeeguu_exercises/static/styles/custom.css
+++ b/src/zeeguu_exercises/static/styles/custom.css
@@ -306,11 +306,20 @@ body
 	background: #cde786;
 }
 
+#typo-information-container
+{
+	height: 62px;
+	line-height: 62px;
+	text-align: center;
+}
+
 #typo-information
 {
+	font-size: 18px;
 	color: #7ca500;
-	text-align: center;
-	margin: 25px auto auto;
+	display: inline-block;
+	vertical-align: middle;
+	line-height: normal;
 }
 
 #ex-footer-secondary

--- a/src/zeeguu_exercises/static/template/exercise/ex1.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex1.html
@@ -33,7 +33,8 @@
                 <button class = " text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div id = "typo-information" class="col-xs-6 h4">
+            <div id = "typo-information-container" class = "col-xs-6">
+							<span id = "typo-information"></span>
             </div>
 
             <div id = "next-exercise"class="col-xs-3 ex-footer-elem ex-clickable secondary-ex-footer-elem ex-footer-elem-right" href="#">

--- a/src/zeeguu_exercises/static/template/exercise/ex4.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex4.html
@@ -35,7 +35,8 @@
                 <button class=" text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div id = "typo-information" class="col-xs-6 h4">
+            <div id = "typo-information-container" class = "col-xs-6">
+							<span id = "typo-information"></span>
             </div>
 
             <div id="next-exercise"


### PR DESCRIPTION
This pull request is for issue #136.

The typo information was not displayed correctly on small screens, because it was pushed down too much by a fixed padding. I used [this StackOverflow answer](https://stackoverflow.com/a/8865463) to implement a vertical center of the line of text. This should resolve the issue, always allowing three lines of text to be properly displayed on small screens. Ironically however, the text is no longer perfectly vertically centered on larger screens, but I suppose this is a detail we can live with.