### PR TITLE
Highlight typos in solution shown on screen

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -40,6 +40,7 @@ function Ex1(data,index,size){
 		this.reStyleDom();
 		this.answer = this.data[this.index].from;
 		this.$descriptionContainer.removeClass('hide');
+		this.$typoInformation.html("");
 		
 		if (!this.isMobile()) {
 			this.$input.val("").focus();

--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -57,7 +57,7 @@ function Ex1(data,index,size){
 	this.reGenerateContext = function(inputWord){
 		var contextString = this.data[this.index].context;
 		var solution = this.data[this.index].from;
-		contextString = contextString.replace(solution, solution.bold().fontcolor(this.colourDarkGreen));
+		contextString = contextString.replace(solution, this.answerWithTyposMarked.bold());
 		this.$context.html (contextString);
 	};
 	

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -54,7 +54,7 @@ function Ex4(data,index,size){
 	
 	this.exerciseSpecificSuccessHandler = function() {
 		// Success handling specific to this exercise
-		var translation = this.data[this.index].to.bold().fontcolor(this.colourDarkGreen);
+		var translation = this.answerWithTyposMarked.bold();
 		this.$to.html (translation);
 		this.$typoInformation.html(this.typoInformation);
 	};

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -37,6 +37,7 @@ function Ex4(data,index,size){
 		this.reStyleDom();
 		this.answer = this.data[this.index].to;
 		this.$descriptionContainer.removeClass('hide');
+		this.$typoInformation.html("");
 		
 		if (!this.isMobile()) {
 			this.$input.val("").focus();

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -41,6 +41,7 @@ Exercise.prototype = {
 	colourDarkGreen: "#7ca500",
 	isMobileDevice: undefined,
 	typoInformation: "",
+	answerWithTyposMarked: "",
 
 	/*********************** General Functions ***************************/
 	/**

--- a/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
@@ -76,17 +76,30 @@ TextInputExercise.prototype.formatStringForCheck = function (text) {
 };
 
 TextInputExercise.prototype.successCondition = function(){
+	this.answerWithTyposMarked = this.answer.trim().replace(/\s\s+/g, ' ');
 	var input = this.$input.val().trim().toUpperCase().replace(/\s\s+/g, ' ');
 	var answer = this.answer.trim().toUpperCase().replace(/\s\s+/g, ' ');
 	
 	// Check exact match
 	if (input === answer) {
+		this.answerWithTyposMarked = this.answerWithTyposMarked.fontcolor(this.colourDarkGreen);
 		this.typoInformation = "";
 		return true;
 	}
 	
 	// Check exact match after removing accents
 	if (removeAccents(input) === removeAccents(answer)) {
+		// Mark typos
+		var markedTypos = "";
+		for (var i = 0; i < answer.length; i++) {
+			if (input.charAt(i) !== answer.charAt(i)) {
+				markedTypos += this.answerWithTyposMarked.charAt(i).fontcolor("red");
+			} else {
+				markedTypos += this.answerWithTyposMarked.charAt(i).fontcolor(this.colourDarkGreen);
+			}
+		}
+		
+		this.answerWithTyposMarked = markedTypos;
 		this.typoInformation = "Pay close attention to the accents!";
 		return true;
 	}

--- a/src/zeeguu_exercises/static/styles/custom.css
+++ b/src/zeeguu_exercises/static/styles/custom.css
@@ -315,7 +315,7 @@ body
 
 #typo-information
 {
-	font-size: 18px;
+	font-size: 30px;
 	color: #7ca500;
 	display: inline-block;
 	vertical-align: middle;

--- a/src/zeeguu_exercises/static/styles/custom.css
+++ b/src/zeeguu_exercises/static/styles/custom.css
@@ -315,11 +315,9 @@ body
 
 #typo-information
 {
-	font-size: 30px;
+	text-align: center;
+	font-size: 24px;
 	color: #7ca500;
-	display: inline-block;
-	vertical-align: middle;
-	line-height: normal;
 }
 
 #ex-footer-secondary
@@ -365,8 +363,8 @@ body
 .ex-content
 {
 	overflow:auto;
-	min-height:250px;
-	max-height:250px;
+	min-height:300px;
+	max-height:300px;
 	text-align: justify;
     text-justify: inter-word;
 	font: 16px arial,sans-serif;

--- a/src/zeeguu_exercises/static/template/exercise/ex1.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex1.html
@@ -10,9 +10,14 @@
 	<div class="row ex-content">			
 		<div class="col-xs-12">
 			<p id = "ex-context" class="h3 clickable-text">						
-			</p>					
+			</p>
+			<br />
+			<p id = "typo-information">
+			</p>
 		</div>		
 	</div>
+	
+	
 
 	<div class="post row ex-footer">
         <div id = "ex-footer-primary" class = "mask mask-appear">
@@ -33,8 +38,7 @@
                 <button class = " text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div id = "typo-information-container" class = "col-xs-6">
-							<span id = "typo-information"></span>
+            <div class = "col-xs-6">
             </div>
 
             <div id = "next-exercise"class="col-xs-3 ex-footer-elem ex-clickable secondary-ex-footer-elem ex-footer-elem-right" href="#">

--- a/src/zeeguu_exercises/static/template/exercise/ex4.html
+++ b/src/zeeguu_exercises/static/template/exercise/ex4.html
@@ -11,7 +11,10 @@
 	<div class="row ex-content">
 		<div class="col-xs-12">
 			<p id = "ex-context" class="h3 clickable-text">						
-			</p>					
+			</p>
+			<br />
+			<p id = "typo-information">
+			</p>			
 		</div>
 	</div>
 	
@@ -35,8 +38,7 @@
                 <button class=" text-btn feedback-text-btn clickable-symbol">Feedback</button>
             </div>
 
-            <div id = "typo-information-container" class = "col-xs-6">
-							<span id = "typo-information"></span>
+            <div class = "col-xs-6">
             </div>
 
             <div id="next-exercise"


### PR DESCRIPTION
This pull request fixes the issues noted by @mircealungu  in #137 .

The typo information has been resized and moved, to better fit with the design principles of the application.

If the learner makes a typo, such as using the wrong accent, the mistaken letter is marked in red, to make it easier for the learner to find what to focus on in order to improve their learning.

(My apologies for the late work, I was not feeling well last week, and took the time (a bit too much) to rest up.)