### PR TITLE
Pressing Enter after Ex2 and Ex3 goes to next exercise

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/ex1.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex1.js
@@ -27,8 +27,8 @@ function Ex1(data,index,size){
 
 		//Next exercise clicked
 		this.$nextExercise.on("click",this.onRenderNextEx.bind(this));
-
-        //Feedback for the previous bookmark: this.index
+		
+		//Feedback for the previous bookmark: this.index
 		this.$feedbackBtn.click(() => {this.giveFeedbackBox(this.index);});
 	};
 	

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -19,6 +19,7 @@ function Ex2(data,index,size){
 		this.$btn2 					= this.$elem.find("#btn2");
 		this.$btn3 					= this.$elem.find("#btn3");
 		this.$nextExercise			= this.$elem.find('#next-exercise');
+		this.$optionBtn = this.$elem.find('.option-btn');
         this.$feedbackBtn			= this.$elem.find('#feedback');
 	}
 	
@@ -138,6 +139,7 @@ function Ex2(data,index,size){
 		// Success handling specific to this exercise
 		var translation = this.data[this.index].to.bold().fontcolor(this.colourDarkGreen);
 		this.$to.html (translation);
+		this.$optionBtn.prop('disabled', true);
 	};
 };
 

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -12,15 +12,15 @@ function Ex2(data,index,size){
 	
 	/** @Override */
 	this.cacheCustomDom = function(){	
-	  this.$to            = this.$elem.find("#ex-to");
-		this.$context 				= this.$elem.find("#ex-context");
-		this.$checkAnswer 			= this.$elem.find("#check_answer");		
-		this.$btn1 					= this.$elem.find("#btn1");
-		this.$btn2 					= this.$elem.find("#btn2");
-		this.$btn3 					= this.$elem.find("#btn3");
-		this.$nextExercise			= this.$elem.find('#next-exercise');
-		this.$optionBtn = this.$elem.find('.option-btn');
-        this.$feedbackBtn			= this.$elem.find('#feedback');
+	  this.$to						= this.$elem.find("#ex-to");
+		this.$context				= this.$elem.find("#ex-context");
+		this.$checkAnswer		= this.$elem.find("#check_answer");		
+		this.$btn1					= this.$elem.find("#btn1");
+		this.$btn2					= this.$elem.find("#btn2");
+		this.$btn3					= this.$elem.find("#btn3");
+		this.$nextExercise	= this.$elem.find('#next-exercise');
+		this.$optionBtn			= this.$elem.find('.option-btn');
+    this.$feedbackBtn		= this.$elem.find('#feedback');
 	}
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex2.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex2.js
@@ -36,12 +36,14 @@ function Ex2(data,index,size){
 		
 		//Bind UI action of button 3 click to the function
 		this.$btn3.on("click", this.btnSelect.bind(this,3));
+		
+		// Bind UI Enter Key
+		$(document).keyup(this.enterKeyup.bind(this));
 
 		//Next exercise clicked
 		this.$nextExercise.on("click",this.onRenderNextEx.bind(this));
-
-
-         //Feedback for the previous bookmark: this.index
+		
+    //Feedback for the previous bookmark: this.index
 		this.$feedbackBtn.click(() => {this.giveFeedbackBox(this.index);});
 	}
 	
@@ -69,6 +71,7 @@ function Ex2(data,index,size){
 		populateButton(this.btns[0], this.data[this.index].from);
 		populateButton(this.btns[1], this.data[idxs[0]].from);
 		populateButton(this.btns[2], this.data[idxs[1]].from);
+		this.$optionBtn.prop('disabled', false);
 
 		this.reStyleDom();
 		this.$to.html ("&zwnj;");

--- a/src/zeeguu_exercises/static/js/app/exercises/ex3.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex3.js
@@ -14,6 +14,7 @@ function Ex3(data,index,size){
 	this.cacheCustomDom = function(data,index,size){
 		this.$to 					= this.$elem.find("#ex-to");
 		this.$context 				= this.$elem.find("#ex-content");
+		this.$checkAnswer 			= this.$elem.find("#check_answer");		
 		this.$showSolution 			= this.$elem.find("#show_solution");
 		this.$btn1 					= this.$elem.find("#btn1");
 		this.$btn2 					= this.$elem.find("#btn2");
@@ -22,6 +23,7 @@ function Ex3(data,index,size){
 		this.$btn5 					= this.$elem.find("#btn5");
 		this.$btn6 					= this.$elem.find("#btn6");
 		this.$nextExercise			= this.$elem.find('#next-exercise');
+		this.$optionBtn = this.$elem.find('.option-btn');
         this.$feedbackBtn			= this.$elem.find('#feedback');
 	};
 	
@@ -47,12 +49,14 @@ function Ex3(data,index,size){
 		
 		//Bind UI action of button 6 click to the function
 		this.$btn6.on("click", this.selectChoice.bind(this,6));
+		
+		// Bind UI Enter Key
+		$(document).keyup(this.enterKeyup.bind(this));
 
 		//Next exercise clicked
 		this.$nextExercise.on("click",this.onRenderNextEx.bind(this));
-
-
-         //Feedback for the previous bookmark: this.index
+		
+    //Feedback for the previous bookmark: this.index
 		this.$feedbackBtn.click(() => {this.giveFeedbackBox(this.index);});
 		
 	};

--- a/src/zeeguu_exercises/static/js/app/exercises/ex3.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex3.js
@@ -1,4 +1,4 @@
-/** Custom exercise formatching 3 words. Inherited from Exercise.js
+/** Custom exercise for matching three pairs of words. Inherited from Exercise.js
  *  @initialize it using: new Ex3();
  *  @customize it by using prototypal inheritance 
 **/
@@ -12,19 +12,19 @@ function Ex3(data,index,size){
 	
 	/** @Override */
 	this.cacheCustomDom = function(data,index,size){
-		this.$to 					= this.$elem.find("#ex-to");
-		this.$context 				= this.$elem.find("#ex-content");
-		this.$checkAnswer 			= this.$elem.find("#check_answer");		
-		this.$showSolution 			= this.$elem.find("#show_solution");
-		this.$btn1 					= this.$elem.find("#btn1");
-		this.$btn2 					= this.$elem.find("#btn2");
-		this.$btn3 					= this.$elem.find("#btn3");	
-		this.$btn4 					= this.$elem.find("#btn4");
-		this.$btn5 					= this.$elem.find("#btn5");
-		this.$btn6 					= this.$elem.find("#btn6");
-		this.$nextExercise			= this.$elem.find('#next-exercise');
-		this.$optionBtn = this.$elem.find('.option-btn');
-        this.$feedbackBtn			= this.$elem.find('#feedback');
+		this.$to						= this.$elem.find("#ex-to");
+		this.$context				= this.$elem.find("#ex-content");
+		this.$checkAnswer		= this.$elem.find("#check_answer");		
+		this.$showSolution	= this.$elem.find("#show_solution");
+		this.$btn1					= this.$elem.find("#btn1");
+		this.$btn2					= this.$elem.find("#btn2");
+		this.$btn3					= this.$elem.find("#btn3");	
+		this.$btn4					= this.$elem.find("#btn4");
+		this.$btn5					= this.$elem.find("#btn5");
+		this.$btn6					= this.$elem.find("#btn6");
+		this.$nextExercise	= this.$elem.find('#next-exercise');
+		this.$optionBtn			= this.$elem.find('.option-btn');
+    this.$feedbackBtn		= this.$elem.find('#feedback');
 	};
 	
 	/** @Override */

--- a/src/zeeguu_exercises/static/js/app/exercises/ex4.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/ex4.js
@@ -24,8 +24,8 @@ function Ex4(data,index,size){
 
 		//Next exercise clicked
 		this.$nextExercise.on("click",this.onRenderNextEx.bind(this));
-
-        //Feedback for the previous bookmark: this.index
+		
+		//Feedback for the previous bookmark: this.index
 		this.$feedbackBtn.click(() => {this.giveFeedbackBox(this.index);});
 	};
 

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -309,6 +309,18 @@ Exercise.prototype = {
 	objectForSpeaker: function(){
 		return {text: this.data[this.index].from, language: this.data[this.index].from_lang};
 	},
+	
+	/**
+	 * Advance the exercise when the enter key is pressed.
+	 **/
+	enterKeyup: function(event){
+		if(event.keyCode == 13){
+			if(!this.getInstanceState())//If in the primary state of footer
+				this.$checkAnswer.click();
+			else //If in the secondary state of footer
+				this.$nextExercise.click();
+		}
+	},
 
 	/*********************** Interface functions *****************************/
 	/**

--- a/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/textInputExercise.js
@@ -32,15 +32,6 @@ TextInputExercise.prototype.cacheCustomDom = function(){
 	this.$typoInformation = this.$elem.find("#typo-information");
 };
 
-TextInputExercise.prototype.enterKeyup = function(event){
-	if(event.keyCode == 13){
-		if(!this.getInstanceState())//If in the primary state of footer
-			this.$checkAnswer.click();
-		else //If in the secondary state of footer
-			this.$nextExercise.click();
-	}
-};
-
 TextInputExercise.prototype.giveHint = function() {
 	// Reveal X letters of the answer, where X is the number of times the Hint button was clicked.
 	var hint = this.answer.slice(0, this.hintsUsed);


### PR DESCRIPTION
This pull request is for #129 .

In Ex1 and Ex4, the text input field has a listener for Enter keypresses. When it is pressed, depending on the program state, the answer is checked or the program advances to the next exercise. In Ex2 and Ex3, this was not the case because there were no text input fields. 

Buttons behave differently when Enter is pressed, because the browser listens for this to 'click' on the button. This caused a bug where, when Enter was pressed after correctly answering Ex2, the green bar disappeared, because the focus was still on the word button and thus it appeared again.

To solve these issues, there is now a document-wide key listener in Ex2 and Ex3. Instead of setting focus to the 'next exercise' button, which would cause a same issue as described above, pressing Enter directly triggers a click on this button.