### PR TITLE
Automatically go to next exercise after reporting feedback

### DIFF
--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -90,7 +90,7 @@ Exercise.prototype = {
 		this.startIndex = index;
 		this.size = size;
 		this.shake = new ShakeAnimation();
-		this.exFeedback = new Feedback(this.resultSubmitSource,this.session);
+		this.exFeedback = new Feedback(this.resultSubmitSource, this.session, this.onRenderNextEx, this);
         Session.getLanguage((text)=>{this.lang = text});//Set the language with callback
 		this.setDescription();
 		this.next();

--- a/src/zeeguu_exercises/static/js/app/exercises/exercise.js
+++ b/src/zeeguu_exercises/static/js/app/exercises/exercise.js
@@ -63,7 +63,6 @@ Exercise.prototype = {
 		this.$descriptionContainer = this.$elem.find('#ex-description-container');
 		this.$exFooterPrimary 	= this.$elem.find('#ex-footer-primary');
 		this.$exFooterSecondary = this.$elem.find('#ex-footer-secondary');
-		this.$deleteBtn			= this.$elem.find('#btn-delete');
 		this.$reportBtn			= this.$elem.find('#btn-report');
 		this.$speakBtn			= this.$elem.find('#btn-speak');
 		this.cacheCustomDom();
@@ -210,16 +209,6 @@ Exercise.prototype = {
 	},
 
 	/**
-	 * Function for deleting bookmark from Zeeguu
-	 * @example https://zeeguu.unibe.ch/api/delete_bookmark/19971?session=34563456
-	 * */
-	deleteBookmark: function (idx) {
-		$.post(Settings.ZEEGUU_API + Settings.ZEEGUU_DELETE_BOOKMARKS + "/" + this.data[idx].id + "?session=" + this.session);
-		this.onRenderNextEx();
-	},
-
-
-	/**
 	 *    Removes focus of page elements
 	 **/
 	prepareDocument: function () {
@@ -276,7 +265,6 @@ Exercise.prototype = {
 	 * */
 	generalBindUIActions: function () {
 		//Bind general actions
-		this.$deleteBtn.click(() => {this.deleteBookmark(this.index);});
 		this.$reportBtn.click(() => {this.giveFeedbackBox(this.index);});
 		this.$speakBtn.click(() => {this.handleSpeak();});
 
@@ -288,7 +276,6 @@ Exercise.prototype = {
 	 * Unbinding of general actions for every exercise
 	 * */
 	generalUnBindUIActions: function () {
-		this.$deleteBtn.off( "click");
 		this.$reportBtn.off( "click");
 		this.$speakBtn.off( "click");
 		//TODO terminate individual bindings for each exercise,

--- a/src/zeeguu_exercises/static/js/app/feedback.js
+++ b/src/zeeguu_exercises/static/js/app/feedback.js
@@ -11,12 +11,16 @@ export default class Feedback {
      * Construct the feedback class
      * @param {number}, id of the current word
      * @param {String}, resultSubmitSource,
+		 * @param {function}, function to be called back after successful feedback,
+		 * @param {this}, scope of callback function,
      * */
-    constructor(resultSubmitSource, sessionId){
+    constructor(resultSubmitSource, sessionId, callback, parentScope){
          /** Class parameters*/
         this.wordId = -1;//will be set whenever the feedback box is called
         this.resultSubmitSource = resultSubmitSource;
         this.sessionId = sessionId;
+				this.callback = callback;
+				this.parentScope = parentScope;
     }
 
     /**
@@ -85,7 +89,7 @@ export default class Feedback {
             closeOnConfirm: false,
             confirmButtonText: "",
         });
-				console.log("Goto next ex");
+				this.callback.call(this.parentScope);
     }
 
     /**

--- a/src/zeeguu_exercises/static/js/app/feedback.js
+++ b/src/zeeguu_exercises/static/js/app/feedback.js
@@ -35,6 +35,7 @@ export default class Feedback {
     feedbackAction(elem){
         this.submitFeedback(this.wordId,elem.attr('value'),this.resultSubmitSource);
         this.successfulFeedback();
+				
     }
 
     /**
@@ -70,7 +71,8 @@ export default class Feedback {
     }
 
     /**
-     * Success message when the feedback is being submitted
+     * Display success message when the feedback is being submitted
+		 * and go to next exercise.
      * */
     successfulFeedback(){
         swal({
@@ -83,6 +85,7 @@ export default class Feedback {
             closeOnConfirm: false,
             confirmButtonText: "",
         });
+				console.log("Goto next ex");
     }
 
     /**
@@ -93,9 +96,11 @@ export default class Feedback {
     exerciseFeedbackOptions(){
         let preDefinedOptions = {
             Options: [
-                {name: "Too easy.", icon: 'static/img/emoji/bored.svg', val: 'too_easy'},
-                {name: "I know it.", icon: 'static/img/emoji/nerd.svg',val: 'i_already_know_this'},
-                {name: "Don't want to see it.", icon: 'static/img/emoji/confused.svg', val: 'dont_show_it_to_me_again'}]
+                {name: "Too Easy", icon: 'static/img/emoji/bored.svg', val: 'too_easy'},
+								{name: "Too Hard", icon: 'static/img/emoji/confused.svg', val: 'too_hard'},
+								{name: "Wrong Example", icon: 'static/img/emoji/confused.svg', val: 'wrong_example'},
+								{name: "Not a Good Example", icon: 'static/img/emoji/nerd.svg', val: 'not_a_good_example'},
+								{name: "Bad Translation", icon: 'static/img/emoji/confused.svg', val: 'bad_translation'}]
         };
         let preOptionTemplate =
             '{{#Options}}' +

--- a/src/zeeguu_exercises/static/template/exercise/exercise.html
+++ b/src/zeeguu_exercises/static/template/exercise/exercise.html
@@ -23,20 +23,11 @@
 						<div id = "ex-status-container" class = "status-animation hide"><svg id = "temp-ex-success" class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><circle class="checkmark__circle" cx="26" cy="26" r="25" fill="none"/><path class="checkmark__check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8"/></svg></div>
 					</div>
 				</div>
-                <div class="col-xs-2">
-
-                        <div class = "btn-group dropdown right-float">
-                            <div class="round-icon-container  dropdown-toggle" type="button" data-toggle="dropdown">
-                                <div class="btn-more"></div>
-                            </div>
-                            <ul class="dropdown-menu">
-                                <li><a id = "btn-delete"><span class="glyphicon glyphicon-trash pull-right"></span>Delete</a></li>
-                                <li class="divider"></li>
-                                <li><a id = "btn-report"><span class="glyphicon glyphicon-send pull-right"></span>Report</a></li>
-                            </ul>
-                        </div>
-
-			    </div>
+				<div class="col-xs-2">
+					<div id ="btn-report" class="round-icon-container right-float" type="button">
+						<div class="btn-more"></div>
+					</div>
+				</div>
             </div>
 			<div id = "custom-content"></div>
 		</div>


### PR DESCRIPTION
This pull request is for #110 and #116 .

When the user presses the dropdown ('...') button, they could choose between 'Delete' and 'Report'. The 'Delete' option automatically advanced to the next exercise, while 'Report' did not. Because 'Delete' is not a necessary option for the user, it has been removed, and pressing the '...' button now opens the Report dialogue right away. The functional code associated with the 'Delete' button is also removed.

The Report dialogue has new predefined options for the user to choose from. After successfully submitting a report, the program now automatically advances to the next exercise. In order to achieve this, a callback between Exercise.js and Feedback.js was necessary.

Note that I did not add any new graphics (emojis and feedback button) since I couldn't find whether the current graphics were used from an online source. I wouldn't be able to emulate the current style by myself, so any new graphics will be a task for the graphic designer of the project.